### PR TITLE
Update link to Part2 module on snaplet tutorial

### DIFF
--- a/project_template/tutorial/src/Tutorial.lhs
+++ b/project_template/tutorial/src/Tutorial.lhs
@@ -56,7 +56,7 @@ use a thread-safe construct such as an MVar or IORef.
 
 This post is written in literate Haskell.  It uses a small external module
 called Part2 that is [available
-here](https://github.com/snapframework/snap/blob/master/project_template/tutorial/src/Part2.lhs).
+here](https://github.com/snapframework/snap-templates/blob/master/project_template/tutorial/src/Part2.lhs).
 You can also install the full code in the current directory with the command
 `snap init tutorial`.  First we need to get imports out of the way.
 


### PR DESCRIPTION
Same as [this fix](https://github.com/snapframework/snap-website/pull/36) for the website, just noticed it in the tutorial file itself.