### PR TITLE
Change source-repository to snap-templates

### DIFF
--- a/snap-templates.cabal
+++ b/snap-templates.cabal
@@ -92,4 +92,4 @@ Executable snap
 
 source-repository head
   type:     git
-  location: https://github.com/snapframework/snap.git
+  location: https://github.com/snapframework/snap-templates.git


### PR DESCRIPTION
Assuming you want to point to this repo.