### PR TITLE
fix deps (directory)

### DIFF
--- a/snap-templates.cabal
+++ b/snap-templates.cabal
@@ -1,5 +1,5 @@
 name:           snap-templates
-version:        1.0.0.0
+version:        1.0.0.1
 synopsis:       Scaffolding CLI for the Snap Framework
 description:
     This is the Scaffolding CLI for the official Snap Framework libraries.
@@ -67,7 +67,7 @@ Executable snap
     base                >= 4       && < 5,
     bytestring          >= 0.9.1   && < 0.11,
     containers          >= 0.3     && < 0.6,
-    directory           >= 1.0     && < 1.3,
+    directory           >= 1.0     && < 1.4,
     directory-tree      >= 0.11    && < 0.13,
     filepath            >= 1.1     && < 1.5,
     -- Blacklist bad versions of hashable


### PR DESCRIPTION
Updated directory upper bound to 1.4 and this seemed to compile and produce a template (and last digit ch on version number of this package).
